### PR TITLE
Add additional Filter-Hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,42 @@ This plugin ensures that Yoast SEO analysize all ACF content including FlexiCont
 Example: exclude text-color field from Yoast scoring.
 
 ```
-add_filter('ysacf_exclude_fields', function(){
-    return array(
+add_filter('ysacf_exclude_fields', function($fields){
+    return array_merge($fields, array(
         'text_color',
-    );
-});
+    ));
+}, 10);
+```
+
+`ysacf_field_overwrite`: Modify a specific field value.
+
+
+Example: Modify a specific field value
+
+```
+add_filter('ysacf_field_overwrite', function($field_key, $field_value, $postID) {
+
+    $data = get_field($field_key, $postID);
+    
+    if($data > 10) {
+        $field_value = $data * 10;
+    }
+
+    return $field_value;
+
+}, 10);
+```
+
+`ysacf_finalize`: filters the data.
+
+
+Example: Append extra data to the final output that is send back to Yoast SEO.
+
+```
+add_filter('ysacf_finalize', function($data, $postID){
+    
+    $data .= 'Modify the final output e.g. append extra data or logic'
+    
+    return $data;
+}, 10);
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Example: exclude text-color field from Yoast scoring.
 ```
 add_filter('ysacf_exclude_fields', function($fields){
     return array_merge($fields, array(
-        'text_color',
+        'text_color'
     ));
 }, 10);
 ```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Example: Append extra data to the final output that is send back to Yoast SEO.
 ```
 add_filter('ysacf_finalize', function($data, $postID){
     
-    $data .= 'Modify the final output e.g. append extra data or logic'
+    $data .= 'Modify the final output e.g. append extra data or logic';
     
     return $data;
 }, 10);

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This plugin ensures that Yoast SEO analysize all ACF content including FlexiCont
 `ysacf_exclude_fields`: exclude acf fields from Yoast scoring.
 
 
-Example: exclude text-color field from Yoast scoring.
+**Example:** exclude text-color field from Yoast scoring.
 
 ```
 add_filter('ysacf_exclude_fields', function($fields){
@@ -18,7 +18,7 @@ add_filter('ysacf_exclude_fields', function($fields){
 `ysacf_field_overwrite`: Modify a specific field value.
 
 
-Example: Modify a specific field value
+**Example:** Modify a specific field value
 
 ```
 add_filter('ysacf_field_overwrite', function($field_key, $field_value, $postID) {
@@ -37,7 +37,7 @@ add_filter('ysacf_field_overwrite', function($field_key, $field_value, $postID) 
 `ysacf_finalize`: filters the data.
 
 
-Example: Append extra data to the final output that is send back to Yoast SEO.
+**Example:** Append extra data to the final output that is send back to Yoast SEO.
 
 ```
 add_filter('ysacf_finalize', function($data, $postID){

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "all3dp/Yoast-SEO-ACF-Content-Analysis",
+    "type": "wordpress-plugin",
+    "require": {
+        "php": ">=5.5",
+        "composer/installers": "*"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "all3dp/Yoast-SEO-ACF-Content-Analysis",
+    "name": "all3dp/yoast-seo-acf-content-analysis",
     "type": "wordpress-plugin",
     "require": {
         "php": ">=5.5",


### PR DESCRIPTION
Hello Angrycreative Team,

thanks for the great work on this plugin! We would like to have additional filter hooks in the plugin.

The reason we need this is because some of the output of our ACF fields depend on conditional logic within ACF and will affect the keyword density calculation as well as keyword suggestions.

Therefor we introduced two new filter one is for modifying the ACF field values and the other one is to control the final output that get's send back to the Yoast SEO backend. 

What do you think?

Thanks,

Alex