### PR TITLE
Add deprecated notice to the readme with link to the new repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## This repository is DEPRECATED
+This repository is deprecated, all development is done at [https://github.com/Yoast/yoast-acf-analysis](https://github.com/Yoast/yoast-acf-analysis).
 # ACF Content Analysis for Yoast SEO
 This plugin ensures that Yoast SEO analysize all ACF content including FlexiContent and Repeaters
 


### PR DESCRIPTION
Fixes [#5](https://github.com/Angrycreative/Yoast-SEO-ACF-Content-Analysis/issues/5)